### PR TITLE
Fix wgEnableProtectionIndicators in ManageWiki

### DIFF
--- a/ManageWikiSettings.php
+++ b/ManageWikiSettings.php
@@ -3979,6 +3979,7 @@ $wgManageWikiSettings = [
 	'wgEnableProtectionIndicators' => [
 		'name' => 'Enable Core Protection Indicators',
 		'from' => 'mediawiki',
+		'global' => true,
 		'type' => 'check',
 		'overridedefault' => false,
 		'section' => 'styling',


### PR DESCRIPTION
Fix found within Miraheze.
`wgEnableProtectionIndicators` needs to has `'global' => true` for the config to shown