### PR TITLE
Add CloudCrafter wiki configuration: new protection levels and Global…

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1496,7 +1496,39 @@ $wgConf->settings += [
 	'wgCommentsDefaultAvatar' => [
 		'default' => '/extensions/SocialProfile/avatars/default_ml.gif',
 	],
+	
+	// GlobalUsage
+	'wgGlobalUsageDatabase' => [
+        'cloudcraftercommonswiki' => 'cloudcraftercommonswiki',
+		'cloudcrafterwiki' => 'cloudcraftercommonswiki',
+	],
+	'wgGlobalUsageSharedRepoWiki' => [
+		'default' => false,
+		'cloudcraftercommonswiki' => 'cloudcraftercommonswiki',
+		'cloudcrafterwiki' => 'cloudcraftercommonswiki',
+	], 
 
+	// Restriction types
+    'wgRestrictionLevels' => [
+	'+cloudcrafterwiki' => [
+	        'editconsulprotected',
+            'editbureaucratprotected',
+	        'editfounderprotected',
+	        'editstaffprotected',
+			'edittemplateprotected',
+		],
+  ],
+	// Rights
+	'+wgAvailableRights' => [
+	     '+cloudcrafterwiki' => [
+	        'editconsulprotected',
+            'editbureaucratprotected',
+	        'editfounderprotected',
+	        'editstaffprotected',
+			'edittemplateprotected',
+		],
+	],
+	
 	// DiscordNotifications
 	'wgDiscordAvatarUrl' => [
 		'default' => '',


### PR DESCRIPTION
This pull request adds configuration entries for the CloudCrafter wikis, including GlobalUsage setup and newly defined protection levels and rights. These updates introduce custom restriction levels such as consul, bureaucrat, founder, staff, and template protections specific to CloudCrafter. The `wg` configuration entries may need to be reviewed and reordered by the tech team to align with the existing structure and placement standards. This change supports the CloudCrafter wiki family integration and is documented in the relevant CloudCrafter wikis.