### PR TITLE
Configure GlobalUsage shared repo mappings for govnp wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1227,7 +1227,7 @@ $wgConf->settings += [
 	'wgGlobalUsageSharedRepoWiki' => [
 		'govnpcommonsbetawiki' => 'govnpcommonsbetawiki',
 		'govnpdevwiki' => 'govnpcommonsbetawiki',
-		'govnpdevwiki' => 'govnpcommonsbetawiki',
+	    'govnpbetawiki' => 'govnpcommonsbetawiki',
 	    'govnpediabetawiki' => 'govnpcommonsbetawiki',
 	],
 	'wgGlobalUsagePurgeBacklinks' => [

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1227,6 +1227,7 @@ $wgConf->settings += [
 	'wgGlobalUsageSharedRepoWiki' => [
 		'govnpbetawiki' => 'govnpbetawiki',
 		'govnpdevwiki' => 'govnpbetawiki',
+	    'govnpediabetawiki' => 'govnpbetawiki',
 	],
 	'wgGlobalUsagePurgeBacklinks' => [
 		'default' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1225,9 +1225,10 @@ $wgConf->settings += [
         'default' => 'wikidb',
     ],
 	'wgGlobalUsageSharedRepoWiki' => [
-		'govnpbetawiki' => 'govnpbetawiki',
-		'govnpdevwiki' => 'govnpbetawiki',
-	    'govnpediabetawiki' => 'govnpbetawiki',
+		'govnpcommonsbetawiki' => 'govnpcommonsbetawiki',
+		'govnpdevwiki' => 'govnpcommonsbetawiki',
+		'govnpdevwiki' => 'govnpcommonsbetawiki',
+	    'govnpediabetawiki' => 'govnpcommonsbetawiki',
 	],
 	'wgGlobalUsagePurgeBacklinks' => [
 		'default' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -1217,13 +1217,20 @@ $wgConf->settings += [
 		'safety@wikioasis.org',
 	],
     ],
-    // GlobalBlocking & GlobalPreferences & GlobalUserPage & GlobalCssJs
+    // GlobalBlocking & GlobalPreferences & GlobalUserPage & GlobalCssJs & GlobalUsage
     'wgGlobalBlockingDatabase' => [
         'default' => 'wikidb',
     ],
     'wgGlobalPreferencesDB' => [
         'default' => 'wikidb',
     ],
+	'wgGlobalUsageSharedRepoWiki' => [
+		'govnpbetawiki' => 'govnpbetawiki',
+		'govnpdevwiki' => 'govnpbetawiki',
+	],
+	'wgGlobalUsagePurgeBacklinks' => [
+		'default' => true,
+	],
     'wgGlobalUserPageAPIUrl' => [
         'default' => 'https://meta.wikioasis.org/api.php',
     ],


### PR DESCRIPTION
Update and defined `$wgGlobalUsageSharedRepoWiki` to map govnp-related wikis (`govnpdevwiki`, `govnpbetawiki`, `govnpediabetawiki`) to  `govnpcommonsbetawiki` for shared file usage tracking. 