### PR TITLE
Removing config for govnp wikis

### DIFF
--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -960,14 +960,6 @@ $wgConf->settings += [
                 'user' => true,
             ],
         ],
-		'+govnpdevwiki' => [
-			'extendedconfirmed' => [
-				'extendedconfirmed' => true,
-			],
-			'templateeditor' => [
-				'templateeditor' => true,
-			],
-		],
         '+metawiki' => [
             'checkuser' => [
                 'abusefilter-privatedetails' => true,

--- a/LocalSettings.php
+++ b/LocalSettings.php
@@ -960,6 +960,14 @@ $wgConf->settings += [
                 'user' => true,
             ],
         ],
+		'+govnpdevwiki' => [
+			'extendedconfirmed' => [
+				'extendedconfirmed' => true,
+			],
+			'templateeditor' => [
+				'templateeditor' => true,
+			],
+		],
         '+metawiki' => [
             'checkuser' => [
                 'abusefilter-privatedetails' => true,
@@ -1235,15 +1243,6 @@ $wgConf->settings += [
         'default' => 'wikidb',
 	'beta' => 'wikidbbeta',
     ],
-	'wgGlobalUsageSharedRepoWiki' => [
-		'govnpcommonsbetawiki' => 'govnpcommonsbetawiki',
-		'govnpdevwiki' => 'govnpcommonsbetawiki',
-	    'govnpbetawiki' => 'govnpcommonsbetawiki',
-	    'govnpediabetawiki' => 'govnpcommonsbetawiki',
-	],
-	'wgGlobalUsagePurgeBacklinks' => [
-		'default' => true,
-	],
     'wgGlobalUserPageAPIUrl' => [
         'default' => 'https://meta.wikioasis.org/api.php',
     ],


### PR DESCRIPTION
As per https://meta.wikioasis.org/wiki/Steward_requests#Wiki_deletion_for_GovNP_Wikis